### PR TITLE
xfsprogs: fix compilation on host without linux headers

### DIFF
--- a/utils/xfsprogs/Makefile
+++ b/utils/xfsprogs/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xfsprogs
 PKG_VERSION:=5.9.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/fs/xfs/xfsprogs
@@ -52,6 +52,9 @@ define Package/xfs-growfs
 $(call Package/xfsprogs/default)
   TITLE:=Utility for increasing the size of XFS filesystems
 endef
+
+CONFIGURE_VARS += \
+	BUILD_CFLAGS="-I$(TOOLCHAIN_DIR)/include"
 
 CONFIGURE_ARGS += \
 	--disable-gettext \


### PR DESCRIPTION
libfrog from xfsprogs does two host tool: gen_crc32table and
crc32selftest. gen_crc32table generates crc32table.h and crc32selftest
verifies that generated file is ok. crc32selftest requires linux
kernel header asm/types.h that might be absent on non-linux build host.

This patch fixes this issue using BUILD_CFLAGS ./configure variable

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: fakeuser
Compile tested: (fake, fake, fake)
Run tested: (fake, fake, fake, tests done)

Description: fake
